### PR TITLE
WIP: Reduce memory overhead of unmatched normal bed by using single shared reference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ addons:
       - libncurses5-dev # samtools
       - unzip # kentools/pcap
       - libcurl4-openssl-dev # many
+      - libgd-dev
+      - libdb-dev
 
 install: true
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGES
 
+## 1.8.7
+
+* Reduce memory overhead when using BED as unmatched normal panel input
+
 ## 1.8.6
 
 * Code modified for overlapping reads. Where reads overlap but carry the same base on each,

--- a/bin/cgpFlagCaVEMan.pl
+++ b/bin/cgpFlagCaVEMan.pl
@@ -341,13 +341,14 @@ sub buildUnmatchedVCFFileListFromReference{
     #Check the tabix file exists.
     my $umBedTabix = $bedloc.".tbi";
     croak("Unmatched bedfile $umBedTabix") if (! -e $umBedTabix);
+		my $umBedTbi = Bio::DB::HTS::Tabix->new(filename => $bedloc);
 	  open($REF, '<', $refFai) or croak("Error opening reference index $refFai: $!");
       while(<$REF>){
         my $line = $_;
         next if($line =~ m/^\s*#/);
         chomp($line);
         my ($chr,undef) = split(/\t/,$line);
-        $fileList->{$chr} = Bio::DB::HTS::Tabix->new(filename => $bedloc);
+        $fileList->{$chr} = $umBedTbi;
       }
     close($REF);
 	}

--- a/lib/Sanger/CGP/CavemanPostProcessing.pm
+++ b/lib/Sanger/CGP/CavemanPostProcessing.pm
@@ -1,5 +1,5 @@
 ##########LICENCE##########
-# Copyright (c) 2014-2018 Genome Research Ltd.
+# Copyright (c) 2014-2019 Genome Research Ltd.
 #
 # Author: CASM/Cancer IT <cgphelp@sanger.ac.uk>
 #
@@ -32,7 +32,7 @@ use Attribute::Abstract;
 use Data::Dumper;
 use base 'Exporter';
 
-our $VERSION = '1.8.6';
+our $VERSION = '1.8.7';
 our @EXPORT = qw($VERSION);
 
 const my $MATCH_CIG => 'M';
@@ -304,7 +304,7 @@ sub _callbackTumFetch{
 			$str = -1;
 		}
 		return unless ($algn->proper_pair == 1);
-    # Ensure that we keep 
+    # Ensure that we keep
     return if((int($flagValue) & 16) != 0 && (int($flagValue) & 32) != 0);
     return if((int($flagValue) & 16) == 0 && (int($flagValue) & 32) == 0);
 
@@ -480,7 +480,7 @@ sub _callbackMatchedNormFetch{
 		my $indelRdCount = 0;
 		my $nom = $algn->qname;
 		return unless ($algn->proper_pair == 1);
-    # Ensure that we keep 
+    # Ensure that we keep
     return if((int($flagValue) & 16) != 0 && (int($flagValue) & 32) != 0);
     return if((int($flagValue) & 16) == 0 && (int($flagValue) & 32) == 0);
 

--- a/lib/Sanger/CGP/CavemanPostProcessor.pm
+++ b/lib/Sanger/CGP/CavemanPostProcessor.pm
@@ -1,5 +1,5 @@
 ##########LICENCE##########
-# Copyright (c) 2014-2018 Genome Research Ltd.
+# Copyright (c) 2014-2019 Genome Research Ltd.
 #
 #Author: CASM/Cancer IT <cgphelp@sanger.ac.uk>
 #
@@ -32,7 +32,7 @@ use Attribute::Abstract;
 use Data::Dumper;
 use base 'Exporter';
 
-our $VERSION = '1.8.6';
+our $VERSION = '1.8.7';
 our @EXPORT = qw($VERSION);
 
 const my $MATCH_CIG => 'M';
@@ -367,7 +367,7 @@ sub _callbackTumFetch{
 
 	if(_isCurrentPosCoveredFromAlignment($algn) == 1){
         return unless ($algn->proper_pair == 1);
-        # Ensure that we keep 
+        # Ensure that we keep
         return if((int($flagValue) & 16) != 0 && (int($flagValue) & 32) != 0);
         return if((int($flagValue) & 16) == 0 && (int($flagValue) & 32) == 0);
         my $this_read;
@@ -402,7 +402,7 @@ sub _callbackTumFetch{
         }
         $tum_readnames->{$rdname}->{$str} = $this_read;
 
-    } # End of if this is a covered position   
+    } # End of if this is a covered position
 
 	return 1;
 }
@@ -558,14 +558,14 @@ sub populate_norms{
         $muts->{'normcvg'} = 0;
     }
     $muts->{'normcvg'} += 1;
- 
+
     if($read->{str} == +1){
         $muts->{'npcvg'} += 1;
     }else{
         $muts->{'nncvg'} += 1;
         $read->{rdPos} = ($read->{ln} - $read->{rdPos}) + 1;
     }
-		
+
 	return if(uc($read->{qbase}) ne uc($mutBase));
 
     #Tum quals
@@ -604,15 +604,15 @@ sub _callbackMatchedNormFetch{
 	return if((int($flagValue) & 1024) != 0);
 	return if((int($flagValue) & 2048) != 0); #Exclude supplementary alignments
 	#Quick check that were covering the base with this read (skips/indels are ignored)
-	
+
     #Calculate other stuff
     my $totalPCovg = 0;
     my $totalNCovg = 0;
     my $indelRdCount = 0;
-    
+
     if(_isCurrentPosCoveredFromAlignment($algn) == 1){
         return unless ($algn->proper_pair == 1);
-        # Ensure that we keep 
+        # Ensure that we keep
         return if((int($flagValue) & 16) != 0 && (int($flagValue) & 32) != 0);
         return if((int($flagValue) & 16) == 0 && (int($flagValue) & 32) == 0);
         my $this_read;


### PR DESCRIPTION
@drjsanger do you agree this is an appropriate patch based on the findings and examples below?

When a bed file is used for UM panel the a new tabix object is created for each reference (for compatibility with VCF model).  By creating a single tabix object and saving the reference to each pointer instead memory can be vastly reduced.

This is more obvious in GRCh38 as >3000 contigs.

I wrote a small script based on the loading method used in `cgpFlagCaVEMan.pl` to illustrate the point:

Current method (stopping at 1k chrs):
```bash
$ /usr/bin/time -f 'Max resident size (kb): %M\nElapsed wall (s): %e' \
  perl sizeOfTabix.pl genome.fa.fai unmatchedNormal.bed.gz 0
Unique mode: New tabix object for each chromosome.
Exiting after 1000 chrs or memory explodes
Max resident size (kb): 7408852
Elapsed wall (s): 21.93
```

New method (stopping at 1k chrs):
```bash
$ /usr/bin/time -f 'Max resident size (kb): %M\nElapsed wall (s): %e' perl sizeOfTabix.pl genome.fa.fai unmatchedNormal.bed.gz 1
Shared mode: ALL chromosomes share SINGLE tabix object.
Exiting after 1000 chrs or memory explodes
Max resident size (kb): 23872
Elapsed wall (s): 0.09
```

As you can see >7GB down to ~23MB, plus far faster (and less I/O).  This is an extra driver for the production system to switch away from the VCF method also.

Script:
```perl
#!/usr/bin/perl

use strict;
use Bio::DB::HTS::Tabix;

my ($refFai, $bedloc, $shared) = @ARGV;

my $fileList = {};
if($shared) {
  print "Shared mode: ALL chromosomes share SINGLE tabix object.\n"
} else {
  print "Unique mode: New tabix object for each chromosome.\n"
}

my $tbibed;
open(my $REF, '<', $refFai) or croak("Error opening reference index $refFai: $!");
while(my $line = <$REF>){
  next if($line =~ m/^\s*#/);
  chomp($line);
  my ($chr,undef) = split(/\t/,$line);
  if($shared) {
    $tbibed = Bio::DB::HTS::Tabix->new(filename => $bedloc) unless($tbibed);
    $fileList->{$chr} = $tbibed;
  } else {
    $fileList->{$chr} = Bio::DB::HTS::Tabix->new(filename => $bedloc);
  }
  if($. == 1000) {
    print "Exiting after $. chrs or memory explodes\n";
    last;
  }
}
close($REF);
```