### PR TITLE
WIP: Handle various formats used by VCF to show no data for sample

### DIFF
--- a/bin/cgpFlagCaVEMan.pl
+++ b/bin/cgpFlagCaVEMan.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 ##########LICENCE##########
-# Copyright (c) 2014-2018 Genome Research Ltd.
+# Copyright (c) 2014-2019 Genome Research Ltd.
 #
 # Author: CASM/Cancer IT <cgphelp@sanger.ac.uk>
 #
@@ -572,8 +572,8 @@ sub runFlagger{
         my $sampleHitCount = 0;
         my $totalSampleCnt = 0;
         foreach my $sampData(@samples){
-          next if($sampData eq ".");
           $totalSampleCnt++;
+          next if($sampData eq q{0:.:.:.:.} || $sampData eq q{-} || $sampData eq q{.});
           #GT:GF:CF:TF:AF	0|0:41:0:0:0
           my ($gentype,@data) = split(':',$sampData);
           my $totalCvg = 0;

--- a/bin/convertVCFUnmatchedToBed.pl
+++ b/bin/convertVCFUnmatchedToBed.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 ############## LICENSE ##############
-# Copyright (c) 2014-2018 Genome Research Ltd.
+# Copyright (c) 2014-2019 Genome Research Ltd.
 #
 # Author: CASM/Cancer IT <cgphelp@sanger.ac.uk>
 #
@@ -106,7 +106,7 @@ const my @BASES => ('A','C','G','T');
 
     for my $i(9..$max_col) {
       $sample_count++;
-      next if($x[$i] =~m/^[.\-]$/);
+      next if($x[$i] eq '0:.:.:.:.' || $x[$i] =~m/^[.\-]$/);
       my @gts = split /:/, $x[$i];
       for my $j(1..$max_allele) {
         next if($base_list[$j-1] eq $refb);

--- a/lib/Sanger/CGP/CavemanPostProcessing.pm
+++ b/lib/Sanger/CGP/CavemanPostProcessing.pm
@@ -32,7 +32,7 @@ use Attribute::Abstract;
 use Data::Dumper;
 use base 'Exporter';
 
-our $VERSION = '1.8.7';
+our $VERSION = '1.8.8';
 our @EXPORT = qw($VERSION);
 
 const my $MATCH_CIG => 'M';

--- a/lib/Sanger/CGP/CavemanPostProcessing/Flagger.pm
+++ b/lib/Sanger/CGP/CavemanPostProcessing/Flagger.pm
@@ -655,8 +655,8 @@ sub getVCFUnmatchedFlag{
   my $sampleHitCount = 0;
   my $totalSampleCnt = 0;
   foreach my $sampData(@samples){
-    next if($sampData eq ".");
     $totalSampleCnt++;
+    next if($sampData eq q{0:.:.:.:.} || $sampData eq q{-} || $sampData eq q{.});
     #GT:GF:CF:TF:AF	0|0:41:0:0:0
     my ($gentype,@data) = split(':',$sampData);
     my $totalCvg = 0;

--- a/lib/Sanger/CGP/CavemanPostProcessor.pm
+++ b/lib/Sanger/CGP/CavemanPostProcessor.pm
@@ -32,7 +32,7 @@ use Attribute::Abstract;
 use Data::Dumper;
 use base 'Exporter';
 
-our $VERSION = '1.8.7';
+our $VERSION = '1.8.8';
 our @EXPORT = qw($VERSION);
 
 const my $MATCH_CIG => 'M';


### PR DESCRIPTION
@drjsanger can you cast your eye over this please.

I've fixed up the vcf to bed code and also investigated and fixed the flagging code.  Not sure why there are 2 sets of code, I've fixed both.  Which one is obsolete?

I also noted that the previous "skip sample" check wasn't functional:

https://github.com/cancerit/cgpCaVEManPostProcessing/blob/cd1e454bec298079fdb8bf7b9c6746b019236736/bin/cgpFlagCaVEMan.pl#L575-L576

In the VCF files the missing data value is `-`, not `.`.  The reason it didn't fail before is that the split here gave an empty array:

https://github.com/cancerit/cgpCaVEManPostProcessing/blob/cd1e454bec298079fdb8bf7b9c6746b019236736/bin/cgpFlagCaVEMan.pl#L578

As you can see I've moved the check after the increment of total sample count so it doesn't get messed up.